### PR TITLE
Fix: Ensure 'root' Directive in Location Blocks & Improve File Extension Verification

### DIFF
--- a/config/basic.conf
+++ b/config/basic.conf
@@ -24,6 +24,7 @@ server {
     }
 
     location /api {
+        root /content;
         allowed_methods POST GET;
     }
 }

--- a/include/Config.hpp
+++ b/include/Config.hpp
@@ -40,6 +40,7 @@ class Config
                            VirtualServer& VirtualServer);
     void fillLocation(std::stringstream& ss, Location& location);
     void validateVirtualServer(VirtualServer& VirtualServer);
+    bool isValidLocation(Location &location);
 
     // get
 

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -1,4 +1,7 @@
 #include "Config.hpp"
+#include "Location.hpp"
+#include "VirtualServer.hpp"
+#include <stdexcept>
 
 Config::Config(const std::string& configFile) : _logger(DEBUG2)
 {
@@ -10,7 +13,16 @@ Config::Config(const std::string& configFile) : _logger(DEBUG2)
                           "' was read with success!");
 }
 
-void Config::validateVirtualServer(VirtualServer& VirtualServer)
+bool Config::isValidLocation(Location& location)
+{
+   if (location.getRoot().empty())
+  {
+      return false;
+  }
+  return true;
+}
+
+void Config::validateVirtualServer(VirtualServer& virtualServer)
 {
     std::string errors;
     if (_hasHost == false || _hasPort == false)
@@ -22,14 +34,25 @@ void Config::validateVirtualServer(VirtualServer& VirtualServer)
         if (_hasPort == false)
             errors += "'port' ";
     }
-    if (VirtualServer.getLocation("/") == NULL)
+    if (virtualServer.getLocation("/") == NULL)
     {
         errors += "Missing required root location '/' ";
     }
     if (errors.empty() == false)
     {
-        _logger.log(ERROR, errors);
+        _logger.log(ERROR, errors + "in the virtual server: " + virtualServer.getServerName());
         throw std::runtime_error("");
+    }
+    std::map<std::string, Location>::iterator it = virtualServer._locations.begin();
+    std::map<std::string, Location>::iterator ite = virtualServer._locations.end();
+    while (it != ite)
+    {
+        if (isValidLocation(it->second) == false)
+        {
+            _logger.log(ERROR, "Missing required root directive in the location: " + it->first + " from virtual server: " + virtualServer.getServerName());
+            throw std::runtime_error("");
+        }
+        it++;
     }
 }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -73,7 +73,7 @@ bool removeLastChar(std::string& word, char delimiter)
 bool isValidExtension(const std::string& fileName, const std::string& extension)
 {
     std::string fileExtension;
-    size_t pos = fileName.find(".");
+    size_t pos = fileName.rfind(".");
 
     if (pos == std::string::npos || (fileName.length() <= extension.length()))
     {


### PR DESCRIPTION
This PR adds validation to ensure that each location block in the configuration file contains a `root` directive. If a location block is missing `root`, the server will now log a clear error message and exit to prevent misconfiguration.  

Additionally, I fixed a bug in file extension verification. Now, the extension is checked from back to front in the filename, ensuring more accurate validation.

**Changes:**  
- Validate that every location block has a `root` directive.  
- Log an error and exit if `root` is missing.  
- Improve file extension checking by scanning from the end of the filename.  