### PR TITLE
Fix Virtual Server Selection – Ignore Port in Host Header (#38)

### DIFF
--- a/config/basic.conf
+++ b/config/basic.conf
@@ -30,15 +30,15 @@ server {
 }
 
 server {
-    host 127.0.0.1;
+    host localhost;
     port 8080;
-    server_name www.example2.com;
+    server_name www.example.com;
 
     error_page 500 /errors/500.html;
     client_max_body_size 1024;
 
     location / {
-        root /var/www/html;
+        root /content;
         redirect /newRoute/;
         allowed_methods GET POST;
     }
@@ -53,7 +53,7 @@ server {
     client_max_body_size 200;
 
     location / {
-        root /var/www/html;
+        root content;
         redirect /newRoute/;
         allowed_methods GET POST;
     }

--- a/src/WebServer.cpp
+++ b/src/WebServer.cpp
@@ -666,7 +666,7 @@ void WebServer::fillResponse(Connection& connection)
 
         if (isCgiRequest(connection, location))
         {
-            _logger.log(INFO, "Handling CGI Request: " + connection.request.method); 
+            _logger.log(INFO, "Handling CGI Request: " + connection.request.method);
             Cgi *cgiInstance = new Cgi(connection);
          	if (access(cgiInstance->getScriptPath().c_str(), X_OK) != 0)
     		{
@@ -802,17 +802,27 @@ void WebServer::buildResponseBuffer(Connection& connection)
     buffer += connection.response.body;
 }
 
-// WIP
+static std::string serverNameWithoutPort(const std::string& serverName)
+{
+    size_t pos = serverName.find(':');
+    if (pos != std::string::npos)
+    {
+		std::string newStr;
+		newStr = serverName.substr(0, pos);
+		newStr = trim(newStr, " \t");
+		return newStr;
+    }
+    return serverName;
+}
+
 void WebServer::identifyVirtualServer(Connection& connection)
 {
 	//based on connection info host:port
     std::pair<uint32_t, uint16_t> key(connection.host, connection.port);
     std::map<std::string, VirtualServer>& vServersFromHostPort =
         _virtualServersLookup[key];
-    std::string serverName = connection.request.headerFields["host"];
-    std::map<std::string, VirtualServer>::iterator it =
-        vServersFromHostPort.find(serverName);
-
+    std::string serverName = serverNameWithoutPort(connection.request.headerFields["host"]);
+    std::map<std::string, VirtualServer>::iterator it = vServersFromHostPort.find(serverName);
     if (it == vServersFromHostPort.end())
     {
         // set default
@@ -1682,9 +1692,9 @@ bool WebServer::isCgiRequest(Connection& connection, Location& location)
 {
     if (location.isCGI() == false)
         return false;
-    
+
     std::string target = connection.request.target;
-    if (target.find("/cgi-bin/") != 0) 
+    if (target.find("/cgi-bin/") != 0)
         return false;
 
     size_t extPos = target.find_last_of('.');


### PR DESCRIPTION
This PR fixes Virtual Server selection by ensuring that the port in the `Host` header is ignored when performing the lookup.  

**Changes:**  
- Extract the hostname from the `Host` header and use it for lookup.  
- Ensure that requests with `Host: example.com:8080` correctly resolve to `example.com`.  
- Confirm no regressions in existing Virtual Server selection.  

**Fixes:** #38